### PR TITLE
[Docs] Add agdq17-layouts to projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ obs.onSwitchScenes((err, data) => {
 
 ## Projects Using **obs-websocket-js**
 _To add your project to this list, submit a Pull Request._
-- none?  
+- [GamesDoneQuick/agdq17-layouts](https://github.com/GamesDoneQuick/agdq17-layouts)
 
 ## [Contributing Guidelines][link-contributing]
 


### PR DESCRIPTION
`obs-websocket-js` was used in `agdq17-layouts` to observe the active scene in OBS and change the behavior of the graphics accordingly. We also had a custom build of `obs-websocket` which could control our custom cropping plugin. Whenever we finished a run and hit "next run" on the schedule, `agdq17-layouts` would tell `obs-websocket` to reset the cropping.