### PR TITLE
Several fixes and refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,29 @@ obs.onAuthenticationSuccess((err, data) => {
 });
 
 obs.onSwitchScenes((err, data) => {
-  console.log('New Active Scene: ', data.sceneName);
+  console.log('New Active Scene:', data.sceneName);
 });
 ```
+
+#### Debugging
+To enable debug logging, set the `DEBUG` environment variable:
+```bash
+# Enables debug logging for all modules of osb-websocket-js
+DEBUG=obs-websocket-js:*
+
+# on Windows
+set DEBUG=obs-websocket-js:*
+```
+
+If you have multiple libraries or application which use the `DEBUG` environment variable, they can be joined with commas:
+```bash
+DEBUG=foo,bar:*,obs-websocket-js:*
+
+# on Windows
+set DEBUG=foo,bar:*,obs-websocket-js:*
+```
+
+For more information, see the [`debug`][link-debug] documentation.
 
 ## TODOs
 - Unit testing / Socket mocking.
@@ -121,3 +141,4 @@ _To add your project to this list, submit a Pull Request._
   [link-samples]: https://github.com/haganbmj/obs-websocket-js/tree/master/samples "Samples"
   [link-changelog]: https://github.com/haganbmj/obs-websocket-js/blob/gh-pages/CHANGELOG.md "Changelog"
   [link-contributing]: .github/CONTRIBUTING.md "Contributing"
+  [link-debug]: https://github.com/visionmedia/debug "Debug Documentation"

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ obs.on('AuthenticationFailure', callback(err, data));
 ```js
 const OBSWebSocket = require('obs-websocket-js');
 
-const obs = new OBSWebSocket('localhost:4444', '$up3rSecretP@ssw0rd');
-
+const obs = new OBSWebSocket();
+obs.connect('localhost:4444', '$up3rSecretP@ssw0rd');
 obs.onAuthenticationSuccess((err, data) => {
   console.log("Success! We're Authenticated.");
 

--- a/README.md
+++ b/README.md
@@ -66,33 +66,42 @@ obs.on('AuthenticationSuccess', callback(err, data));
 obs.on('AuthenticationFailure', callback(err, data));
 ```
 
+#### Handling Errors
+By default, certain types of WebSocket errors will be thrown as uncaught exceptions.
+To ensure that you are handling every error, you must do the following:
+1. Add a `.catch()` handler to every returned Promise.
+2. Add a `error` event listener to the `OBSWebSocket` object.
+
 #### Example
 ```js
 const OBSWebSocket = require('obs-websocket-js');
 
 const obs = new OBSWebSocket();
-obs.connect('localhost:4444', '$up3rSecretP@ssw0rd');
-obs.onAuthenticationSuccess((err, data) => {
-  console.log("Success! We're Authenticated.");
-
-  obs.getSceneList({})
-    .then((data) => {
-      console.log(data.scenes.length + ' Available Scenes!');
-
-      data.scenes.forEach((scene) => {
-        if (scene.name != data.currentScene) {
-          console.log('Found a different scene! Switching to Scene:', scene.name);
-          obs.SetCurrentScene({ 'scene-name': scene.name });
-        }
-      });
-    })
-    .catch((err) => {
-      console.log(err);
+obs.connect('localhost:4444', '$up3rSecretP@ssw0rd')
+  .then(() => {
+	  console.log('Success! We\'re connected & authenticated.');
+	  return obs.getSceneList({});
+  })
+  .then(data => {
+  	console.log(`${data.scenes.length} Available Scenes!`);
+    data.scenes.forEach(scene => {
+      if (scene.name !== data.currentScene) {
+        console.log('Found a different scene! Switching to Scene:', scene.name);
+        obs.setCurrentScene({'scene-name': scene.name});
+      }
     });
-});
+  })
+  .catch(err => { // Ensure that you add a catch handler to every Promise chain.
+    console.log(err);
+  });
 
 obs.onSwitchScenes((err, data) => {
   console.log('New Active Scene:', data.sceneName);
+});
+
+// You must add this handler to avoid uncaught exceptions.
+obs.on('error', err => {
+	console.error('socket error:', err);
 });
 ```
 

--- a/lib/OBSWebSocket.js
+++ b/lib/OBSWebSocket.js
@@ -1,6 +1,6 @@
 const Socket = require('./Socket');
 const Status = require('./Status');
-const log = require('loglevel');
+const debug = require('debug')('obs-websocket-js:Core');
 
 let requestCounter = 0;
 
@@ -11,8 +11,6 @@ function generateMessageId() {
 class OBSWebSocket extends Socket {
   constructor(address, password) {
     super(address, password);
-
-    this.logger = log;
 
     // Bind all event emissions from the socket such that they are marshaled an re-emit at the base OBSWebSocket scope.
     this.on('obs:internal:event', this._handleEvent);
@@ -26,7 +24,7 @@ class OBSWebSocket extends Socket {
 
     return new Promise((resolve, reject) => {
       if (!requestType) {
-        log.error('[Core:send]', Status.REQUEST_TYPE_NOT_SPECIFIED.description);
+        debug('[send] %s', Status.REQUEST_TYPE_NOT_SPECIFIED.description);
         this._doCallback(callback, Status.wrap(Status.REQUEST_TYPE_NOT_SPECIFIED), null);
         reject(Status.wrap(Status.REQUEST_TYPE_NOT_SPECIFIED));
         return;
@@ -37,20 +35,20 @@ class OBSWebSocket extends Socket {
       const messageId = args['message-id'] = generateMessageId(); // eslint-disable-line no-multi-assign
 
       // Submit the request to the websocket.
-      log.debug('[Core:send]', messageId, requestType, args);
       this._socket.send(JSON.stringify(args));
+      debug('[send] %s %s %o', messageId, requestType, args);
 
-      // Asign a temporary event listener for this particular messageId to uniquely identify the response.
+      // Assign a temporary event listener for this particular messageId to uniquely identify the response.
       this.once('obs:internal:message:id-' + messageId, message => {
         // TODO: Do additional stuff with the msg to determine errors, marshaling, etc.
         // message = API.marshalResponse(requestType, message);
 
         if (message.status === 'error') {
-          log.error('[Core:send:Response:reject]', message);
+          debug('[send:Response:reject] %o', message);
           this._doCallback(callback, message, null);
           reject(message);
         } else {
-          log.debug('[Core:send:Response:resolve]', message);
+          debug('[send:Response:resolve] %o', message);
           this._doCallback(callback, null, message);
           resolve(message);
         }

--- a/lib/OBSWebSocket.js
+++ b/lib/OBSWebSocket.js
@@ -23,6 +23,13 @@ class OBSWebSocket extends Socket {
     args = args || {};
 
     return new Promise((resolve, reject) => {
+      if (!this._connected) {
+        debug('[send] %s', Status.NOT_CONNECTED.description);
+        this._doCallback(callback, Status.wrap(Status.NOT_CONNECTED), null);
+        reject(Status.wrap(Status.NOT_CONNECTED));
+        return;
+      }
+
       if (!requestType) {
         debug('[send] %s', Status.REQUEST_TYPE_NOT_SPECIFIED.description);
         this._doCallback(callback, Status.wrap(Status.REQUEST_TYPE_NOT_SPECIFIED), null);
@@ -35,8 +42,12 @@ class OBSWebSocket extends Socket {
       const messageId = args['message-id'] = generateMessageId(); // eslint-disable-line no-multi-assign
 
       // Submit the request to the websocket.
-      this._socket.send(JSON.stringify(args));
       debug('[send] %s %s %o', messageId, requestType, args);
+      try {
+        this._socket.send(JSON.stringify(args));
+      } catch (e) {
+        reject(e);
+      }
 
       // Assign a temporary event listener for this particular messageId to uniquely identify the response.
       this.once('obs:internal:message:id-' + messageId, message => {

--- a/lib/OBSWebSocket.js
+++ b/lib/OBSWebSocket.js
@@ -9,8 +9,8 @@ function generateMessageId() {
 }
 
 class OBSWebSocket extends Socket {
-  constructor(address, password) {
-    super(address, password);
+  constructor() {
+    super();
 
     // Bind all event emissions from the socket such that they are marshaled an re-emit at the base OBSWebSocket scope.
     this.on('obs:internal:event', this._handleEvent);

--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -3,8 +3,8 @@ const EventEmitter = require('events');
 const AuthHashing = require('./AuthHashing');
 const Status = require('./Status');
 const url = require('url');
-const log = require('loglevel');
-log.setLevel('info');
+const debug = require('debug')('obs-websocket-js:Socket');
+const logAmbiguousError = require('./util/logAmbiguousError');
 
 const NOP = function () {};
 
@@ -40,16 +40,16 @@ class Socket extends EventEmitter {
 
     const originalEmit = this.emit;
     this.emit = function () {
-      log.debug('[Socket:emit]', arguments[0], arguments[1]);
+      debug('[emit] %s %o', arguments[0], arguments[1]);
       originalEmit.apply(this, arguments);
     };
 
     this.connect({address})
       .then(() => {
         this.authenticate({password});
-      })
-      .catch(err => {
-        log.error('Connection or Authentication failed.', err);
+      }, err => {
+        // This will only be called if the consumer has not attached their own .catch handler
+        debug('Connection or Authentication failed:', err);
       });
   }
 
@@ -59,7 +59,7 @@ class Socket extends EventEmitter {
     try {
       callback(err, data);
     } catch (e) {
-      log.error('Unable to resolve callback.', e);
+      logAmbiguousError(debug, 'Unable to resolve callback:', e);
     }
   }
 
@@ -79,12 +79,12 @@ class Socket extends EventEmitter {
     }
 
     return new Promise((resolve, reject) => {
-      log.info('Attempting to connect to:', address);
+      debug('Attempting to connect to: %s', address);
       this._socket = new WebSocket('ws://' + address);
 
       this._socket.onopen = () => {
         this._connected = true;
-        log.info('Connection opened:', address);
+        debug('Connection opened: %s', address);
         this.emit('obs:internal:event', {updateType: 'ConnectionOpened'});
         this._doCallback(callback, null, true);
         resolve();
@@ -92,19 +92,19 @@ class Socket extends EventEmitter {
 
       this._socket.onclose = () => {
         this._connected = false;
-        log.info('Connection closed:', address);
+        debug('Connection closed: %s', address);
         this.emit('obs:internal:event', {updateType: 'ConnectionClosed'});
       };
 
       this._socket.onerror = evt => {
         this._connected = false;
-        log.error('Connected failed.', evt.code);
+        debug('Connected failed: %s', evt.code);
         this._doCallback(callback, true, null);
         reject(evt);
       };
 
       this._socket.onmessage = msg => {
-        log.debug('[Socket:OnMessage]', msg);
+        debug('[OnMessage]: %o', msg.data);
 
         const data = camelCaseKeys(JSON.parse(msg.data));
 
@@ -148,11 +148,11 @@ class Socket extends EventEmitter {
 
         return this.send('Authenticate', params, callback)
           .then(() => {
-            log.debug('Authentification Success.');
+            debug('Authentification Success.');
             this.emit('obs:internal:event', {updateType: 'AuthenticationSuccess'});
           })
           .catch(() => {
-            log.error('Authentication Failure.');
+            debug('Authentication Failure.');
             this.emit('obs:internal:event', {updateType: 'AuthenticationFailure'});
           });
       });
@@ -165,7 +165,7 @@ class Socket extends EventEmitter {
    * @category request
    */
   disconnect() {
-    log.debug('Disconnect requested.');
+    debug('Disconnect requested.');
     this._socket.close();
   }
 }

--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -33,7 +33,7 @@ function camelCaseKeys(obj) {
 }
 
 class Socket extends EventEmitter {
-  constructor(address = 'localhost', password = '') {
+  constructor() {
     super();
     this._connected = false;
     this._socket = undefined;
@@ -43,14 +43,6 @@ class Socket extends EventEmitter {
       debug('[emit] %s %o', arguments[0], arguments[1]);
       originalEmit.apply(this, arguments);
     };
-
-    this.connect({address})
-      .then(() => {
-        this.authenticate({password});
-      }, err => {
-        // This will only be called if the consumer has not attached their own .catch handler
-        debug('Connection or Authentication failed:', err);
-      });
   }
 
   _doCallback(callback, err, data) {

--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -55,50 +55,27 @@ class Socket extends EventEmitter {
     }
   }
 
-  // TODO: Break this up a bit.
-  // TODO: Clean up callbacks.
-  connect(args = {}, callback) {
-    args = args || {};
-    let address = args.address || 'localhost';
+  async connect(args = {}, callback) {
+    try {
+      args = args || {};
+      let address = args.address || 'localhost';
 
-    if (!url.parse(address).port) {
-      address += ':' + DEFAULT_PORT;
-    }
+      if (!url.parse(address).port) {
+        address += ':' + DEFAULT_PORT;
+      }
 
-    if (this._connected) {
-      this._socket.close();
-      this._connected = false;
-    }
-
-    return new Promise((resolve, reject) => {
-      debug('Attempting to connect to: %s', address);
-      this._socket = new WebSocket('ws://' + address);
-
-      this._socket.onopen = () => {
-        this._connected = true;
-        debug('Connection opened: %s', address);
-        this.emit('obs:internal:event', {updateType: 'ConnectionOpened'});
-        this._doCallback(callback, null, true);
-        resolve();
-      };
-
-      this._socket.onclose = () => {
+      if (this._connected) {
+        this._socket.close();
         this._connected = false;
-        debug('Connection closed: %s', address);
-        this.emit('obs:internal:event', {updateType: 'ConnectionClosed'});
-      };
+      }
 
-      this._socket.onerror = evt => {
-        this._connected = false;
-        debug('Connected failed: %s', evt.code);
-        this._doCallback(callback, true, null);
-        reject(evt);
-      };
+      await this._connect(address);
+      this._connected = true;
 
-      this._socket.onmessage = msg => {
-        debug('[OnMessage]: %o', msg.data);
-
-        const data = camelCaseKeys(JSON.parse(msg.data));
+      // This handler must be present before we can call _authenticate.
+      this._socket.on('message', data => {
+        debug('[OnMessage]: %o', data);
+        data = camelCaseKeys(JSON.parse(data));
 
         // Emit the message with ID if available, otherwise default to a non-messageId driven event.
         if (data.messageId) {
@@ -106,16 +83,71 @@ class Socket extends EventEmitter {
         } else {
           this.emit('obs:internal:event', data);
         }
-      };
+      });
+
+      await this._authenticate(args.password);
+
+      this._socket.once('close', () => {
+        this._connected = false;
+        debug('Connection closed: %s', address);
+        this.emit('obs:internal:event', {updateType: 'ConnectionClosed'});
+      });
+
+      debug('Connection opened: %s', address);
+      this.emit('obs:internal:event', {updateType: 'ConnectionOpened'});
+      this._doCallback(callback);
+    } catch (err) {
+      this._connected = false;
+      logAmbiguousError(debug, 'Connection failed:', err);
+      this._socket.close();
+      this._doCallback(callback, err);
+      return Promise.reject(err);
+    }
+  }
+
+  /**
+   * Opens a WebSocket connection to an obs-websocket server, but does not attempt any authentication.
+   * @param address {String}
+   * @returns {Promise}
+   * @private
+   */
+  _connect(address) {
+    return new Promise((resolve, reject) => {
+      let settled = false;
+
+      debug('Attempting to connect to: %s', address);
+      this._socket = new WebSocket('ws://' + address);
+
+      // We only handle initial connection errors.
+      // Beyond that, the consumer is responsible for adding their own `error` event listener.
+      this._socket.once('error', error => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        reject(error);
+      });
+
+      this._socket.once('open', () => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        resolve();
+      });
     });
   }
 
-  authenticate(args = {}, callback) {
-    args = args || {};
-    args.password = args.password || '';
-
+  /**
+   * Authenticates to an obs-websocket server. Must already have an active connection before calling this method.
+   * @param [password=''] {String}
+   * @returns {Promise}
+   * @private
+   */
+  _authenticate(password = '') {
     if (!this._connected) {
-      this._doCallback(callback, Status.wrap(Status.NOT_CONNECTED), null);
       return Promise.reject(Status.wrap(Status.NOT_CONNECTED));
     }
 
@@ -130,23 +162,15 @@ class Socket extends EventEmitter {
         // Return early if authentication is not necessary.
         if (!AUTH.required) {
           this.emit('obs:internal:event', {updateType: 'AuthenticationSuccess'});
-          this._doCallback(callback, null, Status.wrap(Status.AUTH_NOT_REQUIRED));
           return Promise.resolve(Status.wrap(Status.AUTH_NOT_REQUIRED));
         }
 
-        const params = {
-          auth: new AuthHashing(AUTH.salt, AUTH.challenge).hash(args.password)
-        };
-
-        return this.send('Authenticate', params, callback)
-          .then(() => {
-            debug('Authentification Success.');
-            this.emit('obs:internal:event', {updateType: 'AuthenticationSuccess'});
-          })
-          .catch(() => {
-            debug('Authentication Failure.');
-            this.emit('obs:internal:event', {updateType: 'AuthenticationFailure'});
-          });
+        return this.send('Authenticate', {
+          auth: new AuthHashing(AUTH.salt, AUTH.challenge).hash(password)
+        }).then(() => {
+          debug('Authentification Success.');
+          this.emit('obs:internal:event', {updateType: 'AuthenticationSuccess'});
+        });
       });
   }
 

--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -52,6 +52,7 @@ class Socket extends EventEmitter {
       callback(err, data);
     } catch (e) {
       logAmbiguousError(debug, 'Unable to resolve callback:', e);
+      this.emit('error', e); // Forward the error so that we're not completely swallowing it.
     }
   }
 

--- a/lib/methodBinding.js
+++ b/lib/methodBinding.js
@@ -1,5 +1,6 @@
 const API = require('./API');
-const log = require('loglevel');
+const debug = require('debug')('obs-websocket-js:api');
+const logAmbiguousError = require('./util/logAmbiguousError');
 
 const eventCallbacks = {};
 
@@ -7,7 +8,7 @@ function iterateEventCallbacks(callbacks, err, data) {
   for (const callback in callbacks) {
     if (typeof callbacks[callback] === 'function') {
       if (err) {
-        log.error(err);
+        logAmbiguousError(debug, 'Callback error:', err);
       }
       callbacks[callback](err, data);
     }

--- a/lib/util/logAmbiguousError.js
+++ b/lib/util/logAmbiguousError.js
@@ -1,0 +1,17 @@
+/**
+ * Disambiguates an "error" and formats it nicely for `debug` output.
+ * Particularly useful when dealing with error response objects from obs-websocket,
+ * which are not actual Error-type errors, but simply Objects.
+ * @param debug - A `debug` instance.
+ * @param prefix - A string to print in front of the formatted error.
+ * @param error - An error of ambiguous type that you wish to log to `debug`. Can be an Error, Object, or String.
+ */
+module.exports = function (debug, prefix, error) {
+  if (error && error.stack) {
+    debug(`${prefix}\n%O`, error.stack);
+  } else if (typeof error === 'object') {
+    debug(`${prefix}\n%O`, error);
+  } else {
+    debug(`${prefix} %s`, error);
+  }
+};

--- a/lib/util/logAmbiguousError.js
+++ b/lib/util/logAmbiguousError.js
@@ -8,9 +8,9 @@
  */
 module.exports = function (debug, prefix, error) {
   if (error && error.stack) {
-    debug(`${prefix}\n%O`, error.stack);
+    debug(`${prefix}\n %O`, error.stack);
   } else if (typeof error === 'object') {
-    debug(`${prefix}\n%O`, error);
+    debug(`${prefix} %o`, error);
   } else {
     debug(`${prefix} %s`, error);
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "Brendan Hagan (haganbmj)",
   "license": "MIT",
   "dependencies": {
-    "loglevel": "^1.4.1",
+    "debug": "^2.6.4",
     "sha.js": "^2.4.8",
     "ws": "^1.1.1"
   },


### PR DESCRIPTION
This gets rid of the `logLevel` dependency in favor of the [`debug`](https://github.com/visionmedia/debug) module. `debug` has a few advantages:

- Because `npm` does some degree of flattening, it's possible that multiple modules (or even the application which consumes `obs-websocket-js`) might end up with the same reference to a `logLevel` instance. This makes it impossible to silence `obs-websocket-js`'s log output without potentially interefering with the log output of other modules or applications running in the same Node.js context.
- `debug` provides a consistent, standardized method of configuration via environment variables.

Closes #32.