### PR TITLE
[Tests] Add basic connection & authentication tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,5 @@ bower_components
 .github
 .travis
 dist
+coverage
+.nyc_output

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,7 @@ CHANGELOG.md
 # Logs
 logs
 *.log
-npm-debug.log* 
+npm-debug.log*
+
+coverage
+.nyc_output

--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -2,7 +2,6 @@ const WebSocket = require('ws');
 const EventEmitter = require('events');
 const AuthHashing = require('./AuthHashing');
 const Status = require('./Status');
-const url = require('url');
 const debug = require('debug')('obs-websocket-js:Socket');
 const logAmbiguousError = require('./util/logAmbiguousError');
 
@@ -61,7 +60,8 @@ class Socket extends EventEmitter {
       args = args || {};
       let address = args.address || 'localhost';
 
-      if (!url.parse(address).port) {
+      // If no port was provided, add the default port.
+      if (!/(?::\d{2,4})/.test(address)) {
         address += ':' + DEFAULT_PORT;
       }
 
@@ -169,7 +169,7 @@ class Socket extends EventEmitter {
         return this.send('Authenticate', {
           auth: new AuthHashing(AUTH.salt, AUTH.challenge).hash(password)
         }).then(() => {
-          debug('Authentification Success.');
+          debug('Authentication Success.');
           this.emit('obs:internal:event', {updateType: 'AuthenticationSuccess'});
         });
       });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "repository": "haganbmj/obs-websocket-js",
   "repoUrl": "https://github.com/haganbmj/obs-websocket-js",
   "scripts": {
-    "test": "npm run static",
+    "test": "npm run static && nyc ava",
+    "report": "nyc report --reporter=html",
     "grunt": "grunt",
     "build": "grunt",
     "watch": "grunt watch",
@@ -27,14 +28,17 @@
     "ws": "^1.1.1"
   },
   "devDependencies": {
+    "ava": "^0.19.1",
     "eslint": "^3.19.0",
     "eslint-config-xo-space": "^0.16.0",
+    "eslint-plugin-ava": "^4.2.0",
     "grunt": "^1.0.1",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-concat": "^1.0.1",
     "grunt-jsdoc-to-markdown": "^2.0.0",
     "grunt-webpack": "^2.0.1",
     "load-grunt-tasks": "^3.5.2",
+    "nyc": "^10.2.0",
     "webpack": "^2.2.1"
   },
   "bugs": {

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "ava"
+  ],
+  "extends": "plugin:ava/recommended"
+}

--- a/test/auth.spec.js
+++ b/test/auth.spec.js
@@ -1,0 +1,102 @@
+const test = require('ava');
+const WebSocket = require('ws');
+const OBSWebSocket = require('../index');
+const SHA256 = require('sha.js/sha256');
+
+function makeServer(port) {
+  return new Promise((resolve, reject) => {
+    const server = new WebSocket.Server({port}, err => {
+      if (err) {
+        return reject(err);
+      }
+
+      resolve(server);
+    });
+  });
+}
+
+test.before(async () => {
+  const server = await makeServer(4444);
+  const passwordedServer = await makeServer(5555);
+
+  server.on('connection', socket => {
+    socket.on('message', message => {
+      const data = JSON.parse(message);
+      let reply = {
+        'message-id': data['message-id']
+      };
+
+      switch (data['request-type']) {
+        case 'GetAuthRequired':
+          reply = Object.assign(reply, {authRequired: false});
+          break;
+        default:
+        // Do nothing.
+      }
+
+      socket.send(JSON.stringify(reply));
+    });
+  });
+
+  const password = 'supersecretpassword';
+  const salt = 'PZVbYpvAnZut2SS6JNJytDm9';
+  const challenge = 'ztTBnnuqrqaKDzRM3xcVdbYm';
+  const secret = new SHA256().update(password).update(salt).digest('base64');
+  const expectedAuthResponse = new SHA256().update(secret).update(challenge).digest('base64');
+
+  passwordedServer.on('connection', socket => {
+    socket.on('message', message => {
+      const data = JSON.parse(message);
+      let reply = {
+        'message-id': data['message-id']
+      };
+
+      switch (data['request-type']) {
+        case 'GetAuthRequired':
+          reply = Object.assign(reply, {
+            authRequired: true,
+            salt,
+            challenge
+          });
+          break;
+        case 'Authenticate':
+          if (data.auth === expectedAuthResponse) {
+            reply = Object.assign(reply, {
+              status: 'ok'
+            });
+          } else {
+            reply = Object.assign(reply, {
+              status: 'error',
+              error: 'Authentication Failed.'
+            });
+          }
+          break;
+        default:
+          // Do nothing.
+      }
+
+      socket.send(JSON.stringify(reply));
+    });
+  });
+});
+
+test('connects when auth is not required', async t => {
+  const obs = new OBSWebSocket();
+  await t.notThrows(obs.connect());
+});
+
+test('connects when auth is required', async t => {
+  const obs = new OBSWebSocket();
+  await t.notThrows(obs.connect({
+    address: 'localhost:5555',
+    password: 'supersecretpassword'
+  }));
+});
+
+test('fails to connect when the wrong password is provided', async t => {
+  const obs = new OBSWebSocket();
+  await t.throws(obs.connect({
+    address: 'localhost:5555',
+    password: 'wrong_password'
+  }));
+});


### PR DESCRIPTION
This adds bare minimum tests that ensure the ability to connect, authenticate, and realize when authentication has failed due to an incorrect password being provided.

I propose two options:
1) Merge this PR as-is just to get _some_ tests on `master`
2) Continue working on this PR until it's reached a level of coverage that we feel comfortable stopping at

My personal preference is to merge this PR right away so that other contributors can have a base to build from, and tests for other portions of code can come in as smaller PRs.

You'll also want to look into getting [Coveralls](https://coveralls.io/) set up.