### PR TITLE
[API] Fix errors caused when .disconnect is called at the wrong time

### DIFF
--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -183,7 +183,9 @@ class Socket extends EventEmitter {
    */
   disconnect() {
     debug('Disconnect requested.');
-    this._socket.close();
+    if (this._socket) {
+      this._socket.close();
+    }
   }
 }
 


### PR DESCRIPTION
The rationale for this change is that it should probably always be safe for a user to call .disconnect, even if it won't do anything. They shouldn't need to check any state before doing so.