### PR TITLE
Fix webpack distributable

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ bower_components
 dist
 coverage
 .nyc_output
+samples

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,12 +15,9 @@ module.exports = function (grunt) {
     webpack: {
       options: require('./webpack.config.js'),
       obswebsocket: {
-        failOnError: false/* ,
-        plugins: [
-          new webpack.optimize.UglifyJsPlugin()
-        ] */
+        failOnError: false
       },
-      obswebsocket_watch: { // eslint-disable-line camelcase
+      obswebsocketWatch: {
         failOnError: false,
         watch: true
       }
@@ -49,6 +46,6 @@ module.exports = function (grunt) {
   require('load-grunt-tasks')(grunt, {scope: 'devDependencies'});
 
   grunt.registerTask('build', ['clean:dist', 'webpack:obswebsocket', 'concat']);
-  grunt.registerTask('watch', ['webpack:obswebsocket_watch']);
+  grunt.registerTask('watch', ['webpack:obswebsocketWatch']);
   grunt.registerTask('default', ['build']);
 };

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To ensure that you are handling every error, you must do the following:
 const OBSWebSocket = require('obs-websocket-js');
 
 const obs = new OBSWebSocket();
-obs.connect('localhost:4444', '$up3rSecretP@ssw0rd')
+obs.connect({ address: 'localhost:4444', password: '$up3rSecretP@ssw0rd' })
   .then(() => {
 	  console.log('Success! We\'re connected & authenticated.');
 	  return obs.getSceneList({});
@@ -121,6 +121,13 @@ DEBUG=foo,bar:*,obs-websocket-js:*
 
 # on Windows
 set DEBUG=foo,bar:*,obs-websocket-js:*
+```
+
+Browser debugging uses `localStorage`
+```
+localStorage.debug = 'obs-websocket-js:*';
+
+localStorage.debug = 'foo,bar:*,obs-websocket-js:*';
 ```
 
 For more information, see the [`debug`][link-debug] documentation.

--- a/lib/OBSWebSocket.js
+++ b/lib/OBSWebSocket.js
@@ -25,15 +25,15 @@ class OBSWebSocket extends Socket {
     return new Promise((resolve, reject) => {
       if (!this._connected) {
         debug('[send] %s', Status.NOT_CONNECTED.description);
-        this._doCallback(callback, Status.wrap(Status.NOT_CONNECTED), null);
-        reject(Status.wrap(Status.NOT_CONNECTED));
+        this._doCallback(callback, Status.NOT_CONNECTED, null);
+        reject(Status.NOT_CONNECTED);
         return;
       }
 
       if (!requestType) {
         debug('[send] %s', Status.REQUEST_TYPE_NOT_SPECIFIED.description);
-        this._doCallback(callback, Status.wrap(Status.REQUEST_TYPE_NOT_SPECIFIED), null);
-        reject(Status.wrap(Status.REQUEST_TYPE_NOT_SPECIFIED));
+        this._doCallback(callback, Status.REQUEST_TYPE_NOT_SPECIFIED, null);
+        reject(Status.REQUEST_TYPE_NOT_SPECIFIED);
         return;
       }
 
@@ -55,11 +55,11 @@ class OBSWebSocket extends Socket {
         // message = API.marshalResponse(requestType, message);
 
         if (message.status === 'error') {
-          debug('[send:Response:reject] %o', message);
+          debug('[send:reject] %o', message);
           this._doCallback(callback, message, null);
           reject(message);
         } else {
-          debug('[send:Response:resolve] %o', message);
+          debug('[send:resolve] %o', message);
           this._doCallback(callback, null, message);
           resolve(message);
         }

--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -74,9 +74,9 @@ class Socket extends EventEmitter {
       this._connected = true;
 
       // This handler must be present before we can call _authenticate.
-      this._socket.on('message', data => {
-        debug('[OnMessage]: %o', data);
-        data = camelCaseKeys(JSON.parse(data));
+      this._socket.onmessage = msg => {
+        debug('[OnMessage]: %o', msg);
+        const data = camelCaseKeys(JSON.parse(msg.data));
 
         // Emit the message with ID if available, otherwise default to a non-messageId driven event.
         if (data.messageId) {
@@ -84,15 +84,15 @@ class Socket extends EventEmitter {
         } else {
           this.emit('obs:internal:event', data);
         }
-      });
+      };
 
       await this._authenticate(args.password);
 
-      this._socket.once('close', () => {
+      this._socket.onclose = () => {
         this._connected = false;
         debug('Connection closed: %s', address);
         this.emit('obs:internal:event', {updateType: 'ConnectionClosed'});
-      });
+      };
 
       debug('Connection opened: %s', address);
       this.emit('obs:internal:event', {updateType: 'ConnectionOpened'});
@@ -121,23 +121,23 @@ class Socket extends EventEmitter {
 
       // We only handle initial connection errors.
       // Beyond that, the consumer is responsible for adding their own `error` event listener.
-      this._socket.once('error', error => {
+      this._socket.onerror = error => {
         if (settled) {
           return;
         }
 
         settled = true;
         reject(error);
-      });
+      };
 
-      this._socket.once('open', () => {
+      this._socket.onopen = () => {
         if (settled) {
           return;
         }
 
         settled = true;
         resolve();
-      });
+      };
     });
   }
 
@@ -149,7 +149,7 @@ class Socket extends EventEmitter {
    */
   _authenticate(password = '') {
     if (!this._connected) {
-      return Promise.reject(Status.wrap(Status.NOT_CONNECTED));
+      return Promise.reject(Status.NOT_CONNECTED);
     }
 
     return this.getAuthRequired()
@@ -163,7 +163,7 @@ class Socket extends EventEmitter {
         // Return early if authentication is not necessary.
         if (!AUTH.required) {
           this.emit('obs:internal:event', {updateType: 'AuthenticationSuccess'});
-          return Promise.resolve(Status.wrap(Status.AUTH_NOT_REQUIRED));
+          return Promise.resolve(Status.AUTH_NOT_REQUIRED);
         }
 
         return this.send('Authenticate', {

--- a/lib/Status.js
+++ b/lib/Status.js
@@ -1,22 +1,9 @@
 module.exports = {
-  wrap(statusType) {
-    const resp = {
-      code: statusType.code,
-      status: statusType.status,
-      description: statusType.description
-    };
-
-    if (statusType.status === 'error') {
-      resp.error = statusType.description;
-    }
-
-    return resp;
-  },
-
   NOT_CONNECTED: {
     code: 'Not Connected',
     status: 'error',
-    description: 'There is no Socket connection available.'
+    description: 'There is no Socket connection available.',
+    error: this.description
   },
   AUTH_NOT_REQUIRED: {
     code: 'Auth Not Required',
@@ -26,6 +13,7 @@ module.exports = {
   REQUEST_TYPE_NOT_SPECIFIED: {
     code: 'Request Type Not Spcecified',
     status: 'error',
-    description: 'A Request Type was not specified.'
+    description: 'A Request Type was not specified.',
+    error: this.description
   }
 };

--- a/samples/node-sample/index.js
+++ b/samples/node-sample/index.js
@@ -7,7 +7,6 @@ ws.onConnectionOpened(() => {
 
   // Send some requests.
   ws.getSceneList(null, (err, data) => {
-    throw "this";
     console.log(err, data);
   });
 

--- a/samples/node-sample/index.js
+++ b/samples/node-sample/index.js
@@ -1,14 +1,13 @@
 const OBSWebSocket = require('../../index.js');
 const ws = new OBSWebSocket();
 
-ws.logger.setLevel('info');
-
 // Declare some events to listen for.
 ws.onConnectionOpened(() => {
   console.log('Connection Opened');
 
   // Send some requests.
   ws.getSceneList(null, (err, data) => {
+    throw "this";
     console.log(err, data);
   });
 
@@ -17,8 +16,4 @@ ws.onConnectionOpened(() => {
   });
 });
 
-// Open the connection and Authenticate if needed. URL defaults to localhost:4444
-// ws = new OBSWebSocket('address', 'password');
-//
-// ws.connect(); // ws.connect('localhost');
-// ws.authenticate('password');
+ws.connect();

--- a/samples/web-sample/obs-websocket-client.html
+++ b/samples/web-sample/obs-websocket-client.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8">
     <script type='text/javascript' src='../../dist/obs-websocket.js'></script>
     <script>
-      var obs = new OBSWebSocket('localhost');
+      localStorage.debug = 'obs-websocket-js:*';
+
+      var obs = new OBSWebSocket();
       // var obs = new OBSWebSocket('localhost:4444', 'password');
 
       // Note that this defaults to localhost:4444. You can open a new connection later by doing the following.
@@ -13,8 +15,7 @@
 
       // If the password was not passed in the constructor, call the following.
       // obs.authenticate({ password: 'password' });
-
-      obs.logger.enableAll();
+      obs.connect('localhost');
 
       // Bind some methods.
       obs.onConnectionOpened(function() {


### PR DESCRIPTION
* Switch back from ws.on('open') to ws.onopen()
* Remove worthless Status.wrap method
* Fix incoming message parsing

<!--
  Please fill out the following information when creating a new pull request
-->

**Related Issue (if applicable):**
none

**General Description:**
Since this doesn't package node's `ws` module, switching back to the base WebSocket onhandlers.
Also cleaned up some of the samples a bit.