### PR TITLE
ci: Generate/update api at end of travis builds, Closes #61

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,6 +7,7 @@ coverage
 .nyc_output
 samples
 es5/
+lib/API.js
 
 # Adding an exclusion for the webpack config to make node 4 travis builds easier.
 webpack.config.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ script:
 
 after_success:
   - npm run node-coveralls
+  - bash ./.travis/update-api.sh
 
 branches:
   except:

--- a/.travis/update-api.js
+++ b/.travis/update-api.js
@@ -1,0 +1,34 @@
+var https = require('https');
+var fs = require('fs');
+var path = require('path');
+
+var outFile = path.join(__dirname, '../lib/API.js');
+
+https.get('https://raw.githubusercontent.com/Palakis/obs-websocket/master/docs/generated/comments.json', (resp) => {
+  var data = '';
+
+  resp.on('data', (chunk) => { data += chunk; });
+  resp.on('end', () => { parseApi(JSON.parse(data)); });
+}).on("error", (err) => { console.log("Error: " + err.message); });
+
+function parseApi(raw) {
+  var api = {
+    availableEvents: [],
+    availableMethods: []
+  };
+
+  Object.keys(raw.events).forEach(key => {
+    raw.events[key].forEach(event => {
+      api.availableEvents.push(event.name);
+    });
+  });
+
+  Object.keys(raw.requests).forEach(key => {
+    raw.requests[key].forEach(event => {
+      api.availableMethods.push(event.name);
+    });
+  });
+
+  console.log(`Found ${api.availableMethods.length} methods, ${api.availableEvents.length} events.`);
+  fs.writeFileSync(outFile, `// This file is generated, do not edit.\nmodule.exports = ${JSON.stringify(api, null, 2)}`)
+}

--- a/.travis/update-api.sh
+++ b/.travis/update-api.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset
+TARGET_BRANCH="master"
+
+if [[ "$TRAVIS_PULL_REQUEST" != "false" ]] || [[ "$TRAVIS_BRANCH" != "$TARGET_BRANCH" ]]
+then
+  echo "Skipping $TARGET_BRANCH api update."
+  exit 0
+fi
+
+npm run update-api
+
+# Apply all changes on top of the latest master commit.
+git remote add upstream "https://$GH_TOKEN@$GH_REF"
+git fetch upstream
+git reset upstream/$TARGET_BRANCH
+git add -A
+git commit -m "api(ci): Update available obs-websocket methods"
+git push -q upstream HEAD:$TARGET_BRANCH

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "main": "es5/index.js",
   "scripts": {
+    "update-api": "node .travis/update-api.js",
     "build": "npm-run-all build:*",
     "build:web": "webpack",
     "build:es5": "babel lib -d es5",


### PR DESCRIPTION
<!--
  Please fill out the following information when creating a new pull request
-->

### Related Issue (if applicable):
#61 

### Description:
Figured generating after everything else would be fine since this will kick off another gh-pages update anyways. It'd be kind of confusing to have an updated gh-pages commit before the master was updated.
Used the built in https library because I didn't want to introduce another dev dependency.