### PR TITLE
api: Ensure `error` emits occur when unhandled Socket errors/messages are encountered

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ notifications:
 env:
   global:
     - GH_REF="github.com/haganbmj/obs-websocket-js"
+    - DEBUG="obs-websocket-js:*"
 
 before_script:
   - nvm install v4

--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -76,10 +76,10 @@ class Socket extends EventEmitter {
         }
 
         this._connected = true;
+        settled = true;
+
         debug('Connection opened: %s', address);
         this.emit('ConnectionOpened');
-
-        settled = true;
         resolve();
       };
 

--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -57,11 +57,12 @@ class Socket extends EventEmitter {
       debug('Attempting to connect to: %s', address);
       this._socket = new WebSocket('ws://' + address);
 
-      // We only handle initial connection errors.
-      // Beyond that, the consumer is responsible for adding their own `error` event listener.
-      // Might be better to wrap this to an EventEmitter so that users aren't overriding this handler. Would still handle the connection error of course.
+      // We only handle the initial connection error.
+      // Beyond that, the consumer is responsible for adding their own generic `error` event listener.
       this._socket.onerror = error => {
         if (settled) {
+          logAmbiguousError(debug, 'Unknown Socket Error', error);
+          this.emit('error', error);
           return;
         }
 
@@ -110,6 +111,7 @@ class Socket extends EventEmitter {
           this.emit(message.updateType, data);
         } else {
           logAmbiguousError(debug, 'Unrecognized Socket Message:', message);
+          this.emit('error', message);
         }
       };
     });

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "watch": "webpack --watch",
     "test": "npm-run-all test:*",
     "test:static": "eslint .",
-    "test:ava": "npm run ava",
+    "test:ava": "npm run ava --serial",
     "report": "nyc report --reporter=text-lcov",
     "node-coveralls": "npm run report | coveralls",
     "ava": "nyc ava --verbose",

--- a/test/auth.spec.js
+++ b/test/auth.spec.js
@@ -144,7 +144,7 @@ test.cb('emits error when an unhandled socket error occurs', t => {
 
   const obs2 = new OBSWebSocket();
   obs2.on('ConnectionOpened', () => {
-    obs2._socket.emit('error');
+    obs2._socket.emit(new Error('abc'));
   });
 
   obs2.on('error', () => {

--- a/test/auth.spec.js
+++ b/test/auth.spec.js
@@ -138,3 +138,42 @@ test.cb('throws AuthenticationFailure', t => {
     t.end();
   });
 });
+
+test.cb('emits error when an unhandled socket error occurs', t => {
+  util.avaTimeout(t, 250);
+
+  const obs2 = new OBSWebSocket();
+  obs2.on('ConnectionOpened', () => {
+    obs2._socket.emit('error');
+  });
+
+  obs2.on('error', () => {
+    t.end();
+  });
+
+  obs2.connect({
+    address: 'localhost:4444'
+  });
+});
+
+test.cb('emits error when an unrecognized socket message is received', t => {
+  util.avaTimeout(t, 250);
+
+  const obs2 = new OBSWebSocket();
+  obs2.on('ConnectionOpened', () => {
+    obs2.send('echo', {
+      emitMessage: {
+        message: 'message'
+      }
+    });
+  });
+
+  obs2.on('error', error => {
+    t.deepEqual(error.message, 'message');
+    t.end();
+  });
+
+  obs2.connect({
+    address: 'localhost:4444'
+  });
+});

--- a/test/auth.spec.js
+++ b/test/auth.spec.js
@@ -72,7 +72,7 @@ test('fails to connect when the wrong password is provided', async t => {
 });
 
 test.cb('emits ConnectionOpened', t => {
-  util.avaTimeout(t, 250);
+  util.avaTimeout(t, 400);
 
   const obs2 = new OBSWebSocket();
   obs2.on('ConnectionOpened', () => {
@@ -85,7 +85,7 @@ test.cb('emits ConnectionOpened', t => {
 });
 
 test.cb('emits ConnectionClosed', t => {
-  util.avaTimeout(t, 250);
+  util.avaTimeout(t, 400);
 
   const obs2 = new OBSWebSocket();
   obs2.on('ConnectionClosed', () => {
@@ -100,7 +100,7 @@ test.cb('emits ConnectionClosed', t => {
 });
 
 test.cb('emits AuthenticationSuccess', t => {
-  util.avaTimeout(t, 250);
+  util.avaTimeout(t, 400);
 
   const obs2 = new OBSWebSocket();
   obs2.on('AuthenticationSuccess', () => {
@@ -114,7 +114,7 @@ test.cb('emits AuthenticationSuccess', t => {
 });
 
 test.cb('emits AuthenticationFailure', t => {
-  util.avaTimeout(t, 250);
+  util.avaTimeout(t, 400);
 
   const obs2 = new OBSWebSocket();
   obs2.on('AuthenticationFailure', () => {
@@ -128,7 +128,7 @@ test.cb('emits AuthenticationFailure', t => {
 });
 
 test.cb('throws AuthenticationFailure', t => {
-  util.avaTimeout(t, 250);
+  util.avaTimeout(t, 400);
 
   const obs2 = new OBSWebSocket();
   obs2.connect({
@@ -140,14 +140,16 @@ test.cb('throws AuthenticationFailure', t => {
 });
 
 test.cb('emits error when an unhandled socket error occurs', t => {
-  util.avaTimeout(t, 250);
+  util.avaTimeout(t, 400);
 
   const obs2 = new OBSWebSocket();
   obs2.on('ConnectionOpened', () => {
-    obs2._socket.emit(new Error('abc'));
+    obs2._socket.onerror('first error message');
+    obs2._socket.onerror('second error message');
   });
 
-  obs2.on('error', () => {
+  obs2.on('error', error => {
+    t.deepEqual(error, 'first error message');
     t.end();
   });
 
@@ -157,7 +159,7 @@ test.cb('emits error when an unhandled socket error occurs', t => {
 });
 
 test.cb('emits error when an unrecognized socket message is received', t => {
-  util.avaTimeout(t, 250);
+  util.avaTimeout(t, 400);
 
   const obs2 = new OBSWebSocket();
   obs2.on('ConnectionOpened', () => {

--- a/test/setup/util.js
+++ b/test/setup/util.js
@@ -1,6 +1,6 @@
 function avaTimeout(t, timeout) {
   setTimeout(() => {
-    t.fail();
+    t.fail(`The test timed out after ${timeout} milliseconds.`);
     t.end();
   }, timeout);
 }


### PR DESCRIPTION
<!--
  Please fill out the following information when creating a new pull request
-->

### Related Issue (if applicable):
n/a

### Description:
`.on('error')` is listed as emitting unhandled socket errors and exceptions, but it wasn't.
Also fixed a sequencing issue I discovered during this where it wasn't marking the connection as `settled` until after `onConnectionXYZ` events were completed - meaning you could encounter socket issues during that time and have them be swallowed as if they were connection issues.