### PR TITLE
test: test actual build output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ before_script:
   - npm install
 
 script:
-  - npm test
   - npm run build
+  - npm test
 
 after_success:
   - bash ./.travis/gh-pages.sh

--- a/test/auth.spec.js
+++ b/test/auth.spec.js
@@ -1,6 +1,6 @@
 const test = require('ava');
 const env = require('./setup/environment');
-const OBSWebSocket = require('../lib/index');
+const OBSWebSocket = require('..');
 const SHA256 = require('sha.js/sha256');
 
 let unauthServer;

--- a/test/events.spec.js
+++ b/test/events.spec.js
@@ -1,6 +1,6 @@
 const test = require('ava');
 const env = require('./setup/environment');
-const OBSWebSocket = require('../lib/index');
+const OBSWebSocket = require('..');
 
 let unauthServer;
 const obs = new OBSWebSocket();

--- a/test/requests.spec.js
+++ b/test/requests.spec.js
@@ -1,6 +1,6 @@
 const test = require('ava');
 const env = require('./setup/environment');
-const OBSWebSocket = require('../lib/index');
+const OBSWebSocket = require('..');
 
 let unauthServer;
 const obs = new OBSWebSocket();


### PR DESCRIPTION
Currently, tests are run against the un-transformed source found in `lib`. This is potentially hazardous, because it is possible for tests to pass but for the published `npm` package to be broken, because the published package is a transformed output of these sources files.

This change ensures that we are always testing against whatever the `main` entrypoint defined in `package.json` is, which helps avoid this scenario where tests pass but the build might be broken.