### PR TITLE
chore: remove es5 build

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,7 +6,6 @@ dist
 coverage
 .nyc_output
 samples
-es5/
 lib/API.js
 
 # Adding an exclusion for the webpack config to make node 4 travis builds easier.

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules
 dist
-es5
 CHANGELOG.md
 
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)

--- a/.travis/gh-pages.sh
+++ b/.travis/gh-pages.sh
@@ -32,7 +32,7 @@ github_changelog_generator -u haganbmj -p obs-websocket-js $RELEASE
 
 # Add all files & ./dist to the new commit.
 git add -A
-git add CHANGELOG.md ./dist ./es5 -f
+git add CHANGELOG.md ./dist -f
 
 git commit -m "${TARGET_BRANCH}: (${VERSION}) ${SHA}"
 git push -q upstream HEAD:$TARGET_BRANCH

--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,6 @@
     "node_modules",
     "bower_components",
     "lib",
-    "es5",
     "samples",
     "test",
     "_config.yml",

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,2 +1,1 @@
-require('babel-polyfill');
 module.exports = require('./OBSWebSocket.js');

--- a/package.json
+++ b/package.json
@@ -13,12 +13,11 @@
     "node",
     "node.js"
   ],
-  "main": "es5/index.js",
+  "main": "lib/index.js",
   "scripts": {
     "update-api": "node .travis/update-api.js",
     "build": "npm-run-all build:*",
     "build:web": "rimraf dist && webpack",
-    "build:es5": "rimraf es5 && babel lib -d es5",
     "watch": "webpack --watch",
     "test": "npm-run-all test:*",
     "test:static": "eslint .",
@@ -29,16 +28,12 @@
     "static": "eslint ."
   },
   "dependencies": {
-    "babel-polyfill": "^6.26.0",
     "debug": "^4.1.0",
     "sha.js": "^2.4.9",
     "ws": "^5.1.0"
   },
   "devDependencies": {
     "ava": "^0.25.0",
-    "babel-cli": "^6.26.0",
-    "babel-preset-env": "^1.6.1",
-    "babel-register": "^6.26.0",
     "babili-webpack-plugin": "=0.1.1",
     "coveralls": "^3.0.0",
     "eslint": "^5.4.0",
@@ -62,27 +57,6 @@
     "files": [
       "test/*.spec.js",
       "!setup/environment.js"
-    ],
-    "require": "babel-register",
-    "babel": "inherit"
-  },
-  "babel": {
-    "presets": [
-      [
-        "env",
-        {
-          "targets": {
-            "node": 4
-          },
-          "debug": true,
-          "include": [
-            "transform-async-to-generator"
-          ],
-          "exclude": [
-            "transform-regenerator"
-          ]
-        }
-      ]
     ]
   }
 }


### PR DESCRIPTION
It is doubtful that there are many users of `obs-websocket-js` still using environments which are limited to ES5. This is a layer of abstraction that I believe we can safely remove.

BREAKING CHANGE: The es5 build has been removed. Users limited to es5 environments should continue using the latest 2.x release.