### PR TITLE
chore(build): speed up builds by specifying node as the target language

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
-language: ruby
-
-rvm:
-  - 2.2.2
+language: node_js
+node_js:
+  - "8"
+  - "10"
 
 cache:
   directories:
@@ -16,7 +16,6 @@ env:
     - DEBUG="obs-websocket-js:*"
 
 before_script:
-  - nvm install node
   - npm install json -g
   - bash ./.travis/pre-build.sh
   - npm install


### PR DESCRIPTION
The current `.travis.yml` specifies `ruby` as the target language. This wastes build time setting up a Ruby environment which is not needed.