### PR TITLE
Export using commonjs-module in webpack so it can be imported using static imports

### DIFF
--- a/.travis/build-types.ts
+++ b/.travis/build-types.ts
@@ -88,6 +88,10 @@ async function getLatestComments(): Promise<any> {
     Authorization: `token ${process.env.GH_TOKEN}`
   };
 
+  if (!process.env.GH_TOKEN) {
+    delete headers.Authorization;
+  }
+
   const latestReleaseResponse = await got('https://api.github.com/repos/Palakis/obs-websocket/releases/latest', {
     json: true,
     headers

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,8 @@ module.exports = {
   output: {
     path: path.join(__dirname, '/dist'),
     filename: '[name].js',
-    library: 'OBSWebSocket'
+    library: 'OBSWebSocket',
+    libraryTarget: 'commonjs-module'
   },
   externals: {
     ws: 'WebSocket'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = {
     path: path.join(__dirname, '/dist'),
     filename: '[name].js',
     library: 'OBSWebSocket',
-    libraryTarget: 'commonjs-module'
+    libraryTarget: 'umd'
   },
   devtool: 'source-map',
   plugins: [


### PR DESCRIPTION
# Related Issue (if applicable):
#170 

### Description:
The dist version can now be imported using static imports. Previously this was not working for me.