### PR TITLE
Support as a CommonJS module in browsers

### DIFF
--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -1,4 +1,4 @@
-const WebSocket = require('ws');
+const WebSocket = require('isomorphic-ws');
 const EventEmitter = require('events');
 const hash = require('./util/authenticationHashing');
 const Status = require('./Status');

--- a/package-lock.json
+++ b/package-lock.json
@@ -5686,6 +5686,11 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "debug": "^4.1.0",
+    "isomorphic-ws": "^4.0.1",
     "sha.js": "^2.4.9",
     "ws": "^5.1.0"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,9 +25,6 @@ module.exports = {
     filename: '[name].js',
     library: 'OBSWebSocket'
   },
-  externals: {
-    ws: 'WebSocket'
-  },
   devtool: 'source-map',
   plugins: [
     new BabiliPlugin({}, {


### PR DESCRIPTION
Hi,

We are considering using `obs-websocket-js` as a npm package in a browser-based application. Currently, it seems that the recommended way to import the  `obs-websocket-js` package into a web application is to refer to the pre-built js bundle from a html file. Instead, we would like to be able to `import 'obs-websocket-js'`, and do the bundling ourselves using Webpack.

`import 'obs-websocket-js'` currently results in `ws` being used instead of the built-in browser `WebSocket` implementation, so this fails in browsers. To fix this, we suggest using the `isomorphic-ws`, package which uses `ws` in node and `global.WebSocket` in browsers.

If we do this, we can also remove the Webpack `externals` configuration that replaces `ws` with `WebSocket` and rely on `isomorphic-ws` to do that for us. 

I think these changes would keep both the NodeJS and pre-built browser bundle use cases intact, but there may be some use case that I have not thought of? Please let me know your thoughs, and thanks for providing this as an open source library. 

Best,
Emil