### PR TITLE
test: remove useless await

### DIFF
--- a/test/auth.spec.js
+++ b/test/auth.spec.js
@@ -8,9 +8,9 @@ let authServer;
 
 const password = 'supersecretpassword';
 
-test.before(async () => {
-  unauthServer = await env.makeServer(4444);
-  authServer = await env.makeServer(4443);
+test.before(() => {
+  unauthServer = env.makeServer(4444);
+  authServer = env.makeServer(4443);
 
   const salt = 'PZVbYpvAnZut2SS6JNJytDm9';
   const challenge = 'ztTBnnuqrqaKDzRM3xcVdbYm';

--- a/test/events.spec.js
+++ b/test/events.spec.js
@@ -6,7 +6,7 @@ let unauthServer;
 const obs = new OBSWebSocket();
 
 test.before(async t => {
-  unauthServer = await env.makeServer(4446);
+  unauthServer = env.makeServer(4446);
   await t.notThrowsAsync(obs.connect({
     address: 'localhost:4446'
   }));

--- a/test/requests.spec.js
+++ b/test/requests.spec.js
@@ -6,7 +6,7 @@ let unauthServer;
 const obs = new OBSWebSocket();
 
 test.before(async t => {
-  unauthServer = await env.makeServer(4445);
+  unauthServer = env.makeServer(4445);
   await t.notThrowsAsync(obs.connect({
     address: 'localhost:4445'
   }));

--- a/test/setup/environment.js
+++ b/test/setup/environment.js
@@ -19,8 +19,8 @@ const onMessage = function (server, message) {
   return JSON.stringify(reply);
 };
 
-async function makeServer(port) {
-  const server = await new WebSocket.Server({port}, err => {
+function makeServer(port) {
+  const server = new WebSocket.Server({port}, err => {
     if (err) {
       throw err;
     }


### PR DESCRIPTION
Constructors cannot be async, so putting an `await` in front of `new WebSocket.Server` does nothing. So, I removed it.

Since this was the only `await` present in `makeServer()`, I was able to remove the `async` from this method entirely. It does not seem to negatively impact the tests at all.