### PR TITLE
test: drop node 8, add node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "8"
   - "10"
+  - "12"
 
 cache:
   directories:


### PR DESCRIPTION
Node 8 has left its maintenance window, and is now unuspported. This PR drops it, and adds Node 12 to our test matrix.