### PR TITLE
Add support for secure websockets

### DIFF
--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -38,7 +38,7 @@ class Socket extends EventEmitter {
     // eslint-disable-next-line no-async-promise-executor
     return new Promise(async (resolve, reject) => {
       try {
-        await this._connect(address);
+        await this._connect(address, Boolean(args.secure));
         await this._authenticate(args.password);
         resolve();
       } catch (err) {
@@ -53,17 +53,17 @@ class Socket extends EventEmitter {
   /**
    * Opens a WebSocket connection to an obs-websocket server, but does not attempt any authentication.
    *
-   * @param {String} address url without ws:// prefix.
+   * @param {String} address url without ws:// or wss:// prefix.
    * @returns {Promise}
    * @private
    * @return {Promise} on attempted creation of WebSocket connection.
    */
-  async _connect(address) {
+  async _connect(address, secure) {
     return new Promise((resolve, reject) => {
       let settled = false;
 
-      debug('Attempting to connect to: %s', address);
-      this._socket = new WebSocket('ws://' + address);
+      debug('Attempting to connect to: %s (secure: %s)', address, secure);
+      this._socket = new WebSocket((secure ? 'wss://' : 'ws://') + address);
 
       // We only handle the initial connection error.
       // Beyond that, the consumer is responsible for adding their own generic `error` event listener.


### PR DESCRIPTION
### Related Issue (if applicable): #195

### Description:
This PR adds support for secure websockets. This is very useful when running obs-websocket behind a proxy like ngrok. This allows OBS to be controlled from HTTPS websites.